### PR TITLE
Add basic Streamlit app

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,14 @@
+import streamlit as st
+import pandas as pd
+
+
+def main():
+    st.title("Zeme Data Explorer")
+    st.write("Simple Streamlit app to explore property data.")
+    df = pd.read_csv("df_zeme.csv")
+    df["Link"] = df["Link"].apply(lambda url: f'<a href="{url}" target="_blank">{url}</a>')
+    st.markdown(df.to_html(escape=False), unsafe_allow_html=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple Streamlit app that loads `df_zeme.csv` and displays it in a dataframe with clickable links

## Testing
- `python -m pip install streamlit` *(fails: Could not find a version that satisfies the requirement streamlit)*
- `python -m py_compile streamlit_app.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68a805b1e4d883229c4c163de1cff02d