### PR TITLE
Display Zeme links via Streamlit LinkColumn

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,11 +6,12 @@ def main():
     st.title("Zeme Data Explorer")
     st.write("Simple Streamlit app to explore property data.")
     df = pd.read_csv("df_zeme.csv")
-
-    df["Link"] = df["Link"].apply(lambda url: f'<a href="{url}" target="_blank">{url}</a>')
-    st.markdown(df.to_html(escape=False), unsafe_allow_html=True)
-
-    st.dataframe(df)
+    st.dataframe(
+        df,
+        column_config={"Link": st.column_config.LinkColumn("Link")},
+        use_container_width=True,
+        height=600,
+    )
 
 
 


### PR DESCRIPTION
## Summary
- Switch to `st.dataframe` for displaying data
- Configure the Link column with `LinkColumn` and responsive layout

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a80c779dbc8322a4a6b87e8b268da8